### PR TITLE
Update to Vello 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ edition = "2021"
 
 [dependencies]
 pollster = { version = "0.4.0", features = ["macro"] }
+skrifa = "0.26.4"
 taffy = { version = "0.7.0", default-features = false, features = [
   "std",
   "taffy_tree",
   "flexbox",
   "content_size",
 ] }
-vello = "0.3.0"
+vello = "0.4.0"
 winit = "0.30.5"
 derive_macros = { path = "derive_macros" }
 serde = "1.0.216"

--- a/src/animations/standard_animation.rs
+++ b/src/animations/standard_animation.rs
@@ -4,6 +4,7 @@ use crate::animations::traits::{Animatable, Interpolate};
 use crate::geometry::{Rect, Vec2};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
+use vello::peniko::color::HueDirection;
 use vello::peniko::Color;
 #[cfg(target_arch = "wasm32")]
 use web_time::{Duration, Instant};
@@ -31,14 +32,16 @@ pub struct StandardAnimation<T: Interpolate> {
     initialized: bool,
 }
 
-impl<T: Interpolate> StandardAnimation<T> {
+impl<T: Interpolate + Default> StandardAnimation<T> {
     pub fn new(duration: Duration, easing: Easing) -> Self {
         Self {
             initialized: false,
             ..Self::initialized(Default::default(), duration, easing)
         }
     }
+}
 
+impl<T: Interpolate> StandardAnimation<T> {
     pub fn initialized(initial_value: T, duration: Duration, easing: Easing) -> Self {
         Self {
             start_value: initial_value,
@@ -171,11 +174,6 @@ impl Interpolate for Rect {
 
 impl Interpolate for Color {
     fn interpolate(&self, end_value: &Self, t: f64) -> Self {
-        Color {
-            r: self.r.interpolate(&end_value.r, t),
-            g: self.g.interpolate(&end_value.g, t),
-            b: self.b.interpolate(&end_value.b, t),
-            a: self.a.interpolate(&end_value.a, t),
-        }
+        self.lerp(*end_value, t as f32, HueDirection::default())
     }
 }

--- a/src/animations/traits.rs
+++ b/src/animations/traits.rs
@@ -1,12 +1,12 @@
 use crate::geometry::Vec2;
 use std::ops::{Add, Sub};
 
-pub trait Interpolate: Copy + PartialEq + Default {
+pub trait Interpolate: Copy + PartialEq {
     fn interpolate(&self, end_value: &Self, t: f64) -> Self;
 }
 
 pub trait Animatable {
-    type Value: Copy + PartialEq + Default;
+    type Value: Copy + PartialEq;
 
     fn is_animating(&self) -> bool;
     fn is_initialized(&self) -> bool;

--- a/src/data/connection.rs
+++ b/src/data/connection.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::PartialEq;
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, FRAC_PI_6};
 use vello::kurbo::{Affine, BezPath, Cap, Circle, Join, Stroke};
-use vello::peniko::{Color, Fill};
+use vello::peniko::{color::palette, Color, Fill};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Multiplicity {
@@ -391,7 +391,7 @@ impl Item for Connection {
             // Draw explicit path points
             for point in self.data.path_points.iter() {
                 if let PathPoint::Explicit(point) = point {
-                    render_point(*point, accent_color, Color::WHITE);
+                    render_point(*point, accent_color, palette::css::WHITE);
 
                     if ghost_point == Some(*point) {
                         show_ghost_point = false
@@ -402,7 +402,7 @@ impl Item for Connection {
             // Draw ghost point
             if ws.hovered_connection == Some(self.key) && show_ghost_point {
                 if let Some(ghost_point) = ghost_point {
-                    render_point(ghost_point, Color::DARK_GRAY, Color::WHITE);
+                    render_point(ghost_point, palette::css::DARK_GRAY, palette::css::WHITE);
                 }
             }
         }

--- a/src/presentation/colors.rs
+++ b/src/presentation/colors.rs
@@ -20,35 +20,35 @@ pub struct Colors {
 impl Colors {
     pub const LIGHT: Colors = Colors {
         workspace_background: Color::WHITE,
-        workspace_dot: Color::rgb8(203, 213, 225),
+        workspace_dot: Color::from_rgb8(203, 213, 225),
 
-        floating_background: Color::rgb8(255, 255, 255),
-        border: Color::rgb8(230, 230, 230),
-        accent: Color::rgb8(13, 153, 255),
+        floating_background: Color::from_rgb8(255, 255, 255),
+        border: Color::from_rgb8(230, 230, 230),
+        accent: Color::from_rgb8(13, 153, 255),
         icon_active: Color::WHITE,
         icon_inactive: Color::BLACK,
 
-        drop_shadow: Color::rgba8(0, 0, 0, 30),
+        drop_shadow: Color::from_rgba8(0, 0, 0, 30),
         hover: Color::BLACK,
 
         text: Color::BLACK,
-        text_secondary: Color::rgb8(100, 100, 100),
+        text_secondary: Color::from_rgb8(100, 100, 100),
     };
 
     pub const DARK: Colors = Colors {
-        workspace_background: Color::rgb8(24, 24, 27),
-        workspace_dot: Color::rgb8(63, 63, 70),
+        workspace_background: Color::from_rgb8(24, 24, 27),
+        workspace_dot: Color::from_rgb8(63, 63, 70),
 
-        floating_background: Color::rgb8(44, 44, 44),
-        border: Color::rgb8(68, 68, 68),
-        accent: Color::rgb8(12, 140, 233),
+        floating_background: Color::from_rgb8(44, 44, 44),
+        border: Color::from_rgb8(68, 68, 68),
+        accent: Color::from_rgb8(12, 140, 233),
         icon_active: Color::WHITE,
         icon_inactive: Color::WHITE,
 
-        drop_shadow: Color::rgba8(0, 0, 0, 200),
+        drop_shadow: Color::from_rgba8(0, 0, 0, 200),
         hover: Color::WHITE,
 
         text: Color::WHITE,
-        text_secondary: Color::rgb8(150, 150, 150),
+        text_secondary: Color::from_rgb8(150, 150, 150),
     };
 }

--- a/src/presentation/fonts.rs
+++ b/src/presentation/fonts.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
+use skrifa::charmap::Charmap;
+use skrifa::instance::{Location, Size};
+use skrifa::metrics::GlyphMetrics;
+use skrifa::{AxisCollection, FontRef, MetadataProvider};
 use std::sync::{Arc, OnceLock};
 use vello::peniko::{Blob, Font};
-use vello::skrifa::charmap::Charmap;
-use vello::skrifa::instance::{Location, Size};
-use vello::skrifa::metrics::GlyphMetrics;
-use vello::skrifa::{AxisCollection, FontRef, MetadataProvider};
 
 macro_rules! font {
     ($name:ident, $file:expr, $weight:expr) => {


### PR DESCRIPTION
* skrifa is no longer part of the public API, so depend on it separately.
* Vello now uses the new `color` crate. The color type does not impl `Default`, so a small change to the animation code here is needed.
* Use the `lerp` function from `color` to handle color interpolation.
* Named colors are available via `color::palette::css` rather than as named constants on the `Color` type.